### PR TITLE
Fix sorting of the date column on Safari.

### DIFF
--- a/render-ws/src/main/webapp/script/janelia-render.js
+++ b/render-ws/src/main/webapp/script/janelia-render.js
@@ -661,7 +661,7 @@ JaneliaRenderServiceDataUI.prototype.getStackSummaryHtml = function(ownerUrl, st
            '  <td class="number">' + values[4] + '</td>\n' +
            '  <td class="number">' + values[5] + '</td>\n' +
            '  <td class="number">' + values[6] + '</td>\n' +
-           '  <td class="number">' + values[7] + '</td>\n' +
+           '  <td>' + values[7] + '</td>\n' +
            '  <td>' + linksHtml + '</td>\n' +
            '</tr>\n';
 };

--- a/render-ws/src/main/webapp/script/stacks.js
+++ b/render-ws/src/main/webapp/script/stacks.js
@@ -54,6 +54,8 @@ var RenderWebServiceProjectStacks = function(ownerSelectId, projectSelectId, mes
             }
         };
 
+        $.tablesorter.clearTableBody( $("#stackInfo")[0] );
+
         var projectStackMetaDataList = renderData.getProjectStackMetaDataList();
         var summaryHtml;
         for (var index = 0; index < projectStackMetaDataList.length; index++) {

--- a/render-ws/src/main/webapp/view/stacks.html
+++ b/render-ws/src/main/webapp/view/stacks.html
@@ -15,10 +15,10 @@
 
     <script type="text/javascript">
         $( document ).ready(function() {
+            $("#stackInfo").tablesorter( { } );
+
             //noinspection JSUnusedLocalSymbols
             var stacksUi = new RenderWebServiceProjectStacks('renderStackOwner', 'renderStackProject', 'message', 'urlToView');
-
-            $("#stackInfo").tablesorter( { } );
         });
 
     </script>
@@ -64,8 +64,8 @@
                 <th>Layer Count</th>
                 <th>Tile Count</th>
                 <th>Shared Transform Count</th>
-                <th>Last Modified</th>
-                <th>Actions</th>
+                <th data-sorter="usLongDate">Last Modified</th>
+                <th data-sorter="false">Actions</th>
             </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
Small fixes to make Safari happy, including properly destroying the old table before creating new content, and using long dates.